### PR TITLE
Hopefully fix build instructions and fix quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,36 @@ cmake ../extra-deps/tensorflow/tensorflow/lite
 cmake --build . -j
 ```
 
+## Installing the TensorFlow C-libraries
+
+The TensorFlow C-bindings are required to build this project. In order to
+install them, follow the instructions provided by
+[TensorFlow](https://www.tensorflow.org/install/lang_c). Make sure to install
+the TensorFlow 2.3.0
+[CPU](https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz)
+or
+[GPU](https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.3.0.tar.gz)
+bindings, and not the latest version, since this is the version required by the
+TensorFlow-Haskell dependency. As such, we recommend not installing in the
+default location (/usr/local on Linux or MacOS systems), but to a different
+location. To make sure the build succeeds, you need to tell stack where to find
+these files, using the `extra-lib-dirs` and `extra-include-dirs` fields. Make
+sure to set the `LIBRARY_PATH` and `LD_LIBRARY_PATH` as described in the
+installation instructions as well.
+
+## Installing protoc
+
+To build the required TensorFlow and TensorFlow-haskell packages, you need to
+have protoc installed. If you do not have it installed, follow the directions on
+[this webpage](https://google.github.io/proto-lens/installing-protoc.html).
+
+## Installing other dependencies
+
+Other dependencies have to be installed manually before running `stack build`.
+Among these are cpuinfo, farmhash. (TODO: find out what exactly is on this
+list.) These exist in the Ubuntu package management system and can be installed
+through apt:
+```bash
+sudo apt install libcpuinfo-dev libfarmhash-dev
+```
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ To build the required TensorFlow and TensorFlow-haskell packages, you need to
 have protoc installed. If you do not have it installed, follow the directions on
 [this webpage](https://google.github.io/proto-lens/installing-protoc.html).
 
+## Installing the edgetpu library
+
+TODO: Make sure everything in this section is correct; at the moment, the list
+of what to install might be incomplete.
+TODO: non-debian Linux instructions.
+Follow the instructions from [Coral](https://coral.ai/software/#debian-packages) to get access to their debian packages through apt(-get). Then, install the following libraries:
+ - libedgetpu-dev (TODO: check necessity, probably required)
+ - edgetpu\_compiler
+ - libedgetpu1-std (recommended unless the higher frequency is required)
+
 ## Installing other dependencies
 
 Other dependencies have to be installed manually before running `stack build`.

--- a/accelerate-tensorflow-lite/package.yaml
+++ b/accelerate-tensorflow-lite/package.yaml
@@ -41,7 +41,7 @@ dependencies:
 
 library:
   source-dirs: src
-  c-sources: cbits/edgetpu.cc
+  cxx-sources: cbits/edgetpu.cc
 
   exposed-modules:
     - Data.Array.Accelerate.TensorFlow.Lite
@@ -56,17 +56,17 @@ library:
     -march=native
 
   extra-libraries:
-    - stdc++
-    - clog
-    - cpuinfo
-    - edgetpu
-    - farmhash
-    - fft2d_fftsg
-    - fft2d_fftsg2d
-    - flatbuffers
-    - pthreadpool
-    - ruy
-    - tensorflow-lite
-    - XNNPACK
+      stdc++
+      clog
+      cpuinfo
+      edgetpu
+      farmhash
+      tensorflow-lite
+      ruy
+      XNNPACK
+      flatbuffers
+      pthreadpool
+      fft2d_fftsg
+      fft2d_fftsg2d
 
 # vim: nospell

--- a/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
+++ b/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
@@ -109,8 +109,8 @@ tflite_model graph = do
       inputs  = filter (T.isPrefixOf "input") names
       outputs = filter (T.isPrefixOf "output") names
       --
-      cp      = (proc "tflite_convert" flags) { std_in = NoStream, std_out = NoStream, std_err = CreatePipe }
-      flags   = [ "--enable_v1_converter"
+      cp      = (proc "python3" flags) { std_in = NoStream, std_out = NoStream, std_err = CreatePipe }
+      flags   = [ "converter.py"
                 , "--graph_def_file=" ++ pb_file
                 , "--output_file=" ++ tf_file
                 , "--input_arrays=" ++ T.unpack (T.intercalate "," inputs)
@@ -129,7 +129,7 @@ tflite_model graph = do
     -- wait on the process
     ex <- waitForProcess ph
     case ex of
-      ExitFailure r -> error $ printf "tflite_convert %s (exit %d)\n%s" (unwords flags) r err
+      ExitFailure r -> error $ printf "python3 %s (exit %d)\n%s" (unwords flags) r err
       ExitSuccess   -> return ()
 
   removeFile pb_file

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,75 @@
+import tensorflow as tf
+import numpy as np
+
+import sys
+
+# TODO: make sure this takes data from the Accelerate compiler. Right now it
+# has the following assumptions:
+#   1. There are exactly 2 input arrays
+#   2. The shape of both arrays is [100]
+#   3. The representative dataset is random floats in range [0.0, 10.0)
+def representative_data_gen(rng):
+    for _ in range(0, 10):
+        x = rng.random([100], dtype=np.float32) * 10.0
+        y = rng.random([100], dtype=np.float32) * 10.0
+
+        yield [x, y]
+
+# Parses command-line arguments
+# Options are:
+#   --graph_def_file=" pb_file
+#   --output_file=" tflite_file
+#   --input_arrays="  comma-separated list of names of  input arrays
+#   --output_arrays=" comma-separated list of names of output arrays
+# TODO: the following changes need to happen at some point:
+#    1. sanitize the data in in_arrs and out_arrs before setting their values.
+#    2. Accept a cli-arg that describes what representative data there is, how
+#       to get it, and how to use it.
+def parse_args(args):
+    graph_def = None
+    outfile = None
+    in_arrs = None
+    out_arrs = None
+
+    for arg in args:
+        if arg.startswith('--graph_def_file='):
+            graph_def = arg[17:]
+            pass
+        elif arg.startswith('--output_file='):
+            outfile = arg[14:]
+            pass
+        elif arg.startswith('--input_arrays='):
+            in_arrs = arg[15:]
+            pass
+        elif arg.startswith('--output_arrays='):
+            out_arrs = arg[16:]
+            pass
+
+    return (graph_def, outfile, in_arrs, out_arrs)
+
+
+def main():
+    in_file, out_file, inputs, outputs = parse_args(sys.argv)
+
+    rng = np.random.default_rng()
+
+    # TODO: use the inputs and outputs values
+    converter = tf.compat.v1.lite.TFLiteConverter.from_frozen_graph(
+        graph_def_file=in_file
+      , input_arrays=['input0_adata0', 'input1_adata0']
+      , output_arrays=['output0_adata0']
+      )
+
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: representative_data_gen(rng))
+
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    converter.target_spec.supported_types = [tf.int8]
+
+    tflite_model = converter.convert()
+    with tf.io.gfile.GFile(out_file, 'wb') as f:
+      f.write(tflite_model)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
The changes to the build files should help a lot in fixing the build errors. The linker now happens in the correct order, which was an issue on at least two different machines, and this has been fixed. Additionally, the `c-sources` field in the `package.yaml` file has been changed to `cxx-sources` for similar reasons.

The quantization should work now, but this currently also breaks programs that do not have exactly two inputs of shape `[100]`. It also makes the build less stable, since the program just calls `python3` on a script that needs to live next to the executable.
The problem with the inputs is documented and there are some other TODO comments in the script. I think the best way to fix the other program with the script (running `python3`) would be to somehow make a executable out of this that we can install using stack, or using pip3 by calling it in the stack build process.