### PR TITLE
Representative data passing

### DIFF
--- a/accelerate-tensorflow-lite/cbits/edgetpu.cc
+++ b/accelerate-tensorflow-lite/cbits/edgetpu.cc
@@ -45,8 +45,9 @@ extern "C" void edgetpu_run(const char* model_path, const char** tensor_name, ui
     auto input_name = interpreter->GetInputName(i);
 
     for (size_t j = 0; j < tensor_count; ++j) {
-      if (0 == strcmp(input_name, tensor_name[i])) {
-        memcpy(interpreter->typed_input_tensor<uint8_t*>(j), tensor_data[j], tensor_size_bytes[j]);
+      if (0 == strcmp(input_name, tensor_name[j])) {
+        auto tensor = interpreter->typed_input_tensor<float>(i);
+        memcpy(tensor, tensor_data[j], tensor_size_bytes[j]);
         break;
       }
     }
@@ -61,10 +62,10 @@ extern "C" void edgetpu_run(const char* model_path, const char** tensor_name, ui
     auto output_name = interpreter->GetOutputName(i);
 
     for (size_t j = 0; j < tensor_count; ++j) {
-      if (0 == strcmp(output_name, tensor_name[i])) {
+      if (0 == strcmp(output_name, tensor_name[j])) {
         // TODO: Assumes that the size of the output tensor data is known
         // statically, but we should really get it from the output?_shape
-        memcpy(tensor_data[j], interpreter->typed_output_tensor<uint8_t*>(i), tensor_size_bytes[j]);
+        memcpy(tensor_data[j], interpreter->typed_output_tensor<float>(i), tensor_size_bytes[j]);
         break;
       }
     }

--- a/accelerate-tensorflow-lite/converter.py
+++ b/accelerate-tensorflow-lite/converter.py
@@ -16,37 +16,11 @@ def representative_data_gen(rng):
 
         yield [x, y]
 
-# TODO: make a representative data reader. Accelerate can output data through
-# the Data.Array.Accelerate.IO.Data.ByteStrings module. The data this spits out
-# is nothing but a list of bytes representing the data; on my machine, this is
-# in little-endian format, but it is possible that other machines expect it in
-# a different format. I do expect, though, that reading will expect the same
-# format that the machine spits out.
+# This script might need some additional data to work.
+# TODO
 #
-# The idea on how to make this work, is that Accelerate needs to tell this
-# script a few things:
-#   - Where to find this data
-#   - (Something else? TODO)
-#
-# This script can then read that data and use it in a representative_data
-# function (closure?)
-# The structure of the data is preferred to be as follows: (taken from the
-# GitHub issue #3)
-#
-# {
-# "representative data": [
-#   [{ "shape": <some shape descriptor>, "data": [...data...] }, ...],
-#   [{ "shape": <the same shape descriptor>, "data": [...data...] }, ...],
-#   ...
-# ]
-# }
-#
-# Except, obviously, in binary form; the outer object is nullified in this
-# case, and the shape descriptor needs work. The data can be the verbatim
-# output of Accelerate's ByteString IO.
-#
-# EDIT: New format specified in pseudo-BNF:
-# representative_data_file -> tensor_count dataset_count dataset*
+# Format specified in pseudo-BNF:
+# representative_data_file -> tensor_count dataset_count dataset+
 # tensor_count -> i32
 # dataset_count -> i32
 # dataset -> shape data
@@ -54,10 +28,10 @@ def representative_data_gen(rng):
 # data -> f32+ (the amount of f32s is the product of the dimensions from the shape)
 def parse_representative_data_file(file_path):
     with open(file_path, "rb") as f:
-        # Parse the amount of input tensors (Assume int16 for now)
+        # Parse the amount of input tensors
         tensor_count = read_int32(f)
 
-        # Parse the amount of representative datasets (assume int32 for now)
+        # Parse the amount of representative datasets
         dataset_count = read_int32(f)
 
         for _ in range(dataset_count):
@@ -66,7 +40,8 @@ def parse_representative_data_file(file_path):
                 shape = read_shape(f)
                 # Parse the data (TODO assuming f32 data?)
                 data = read_data(f, shape)
-                tensors.push(data)
+                np_data = np.array(data, dtype=np.float32)
+                tensors.append(np_data)
 
             #end
             yield tensors
@@ -79,7 +54,7 @@ def parse_representative_data_file(file_path):
 def read_int32(f):
     b = bytearray(4)
     f.readinto(b)
-    return struct.unpack("l", b)[0]
+    return struct.unpack("i", b)[0]
 
 
 # Reads a 32-bit integer which describes the amount of dimensions the data has,
@@ -88,13 +63,13 @@ def read_shape(f):
     dims = read_int32(f)
     b = bytearray(dims * 4)
     f.readinto(b)
-    return struct.unpack("l" * dims, b)
+    return struct.unpack("i" * dims, b)
 
 
 # Reads f32 data, the amount of which is the product of all dimensions in the shape
 def read_data(f, shape):
-    # Apparently functional style is not "pythonic" so here we go, have a foldl
-    # (*) 1:
+    # Apparently functional style is not "pythonic" so here we go, have a
+    # foldl (*) 1:
     res = 1
     for x in shape:
         res *= x
@@ -115,8 +90,6 @@ def read_data(f, shape):
 #   --data_path= representative_data_file (see parse_representative_data_file)
 # TODO: the following changes need to happen at some point:
 #    1. sanitize the data in in_arrs and out_arrs before setting their values.
-#    2. Accept a cli-arg that describes what representative data there is, how
-#       to get it, and how to use it.
 def parse_args(args):
     graph_def = None
     outfile = None
@@ -155,7 +128,6 @@ def main():
 
     rng = np.random.default_rng()
 
-    # TODO: use the inputs and outputs values
     converter = tf.compat.v1.lite.TFLiteConverter.from_frozen_graph(
         graph_def_file=in_file
       , input_arrays=inputs
@@ -163,11 +135,13 @@ def main():
       )
 
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    if data_path != None:
-        # I don't know how to break this line... Python why
-        converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: parse_representative_data_file(data_path))
+    if data_path:
+        converter.representative_dataset = tf.lite.RepresentativeDataset(
+                lambda: parse_representative_data_file(data_path))
     else:
-        converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: representative_data_gen(rng))
+        # TODO make this an error instead? It's likely to give an error otherwise, anyway...
+        converter.representative_dataset = tf.lite.RepresentativeDataset(
+                lambda: representative_data_gen(rng))
     #end
 
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]

--- a/accelerate-tensorflow-lite/converter.py
+++ b/accelerate-tensorflow-lite/converter.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 import numpy as np
 
 import sys
+import struct
 
 # TODO: make sure this takes data from the Accelerate compiler. Right now it
 # has the following assumptions:
@@ -15,12 +16,103 @@ def representative_data_gen(rng):
 
         yield [x, y]
 
+# TODO: make a representative data reader. Accelerate can output data through
+# the Data.Array.Accelerate.IO.Data.ByteStrings module. The data this spits out
+# is nothing but a list of bytes representing the data; on my machine, this is
+# in little-endian format, but it is possible that other machines expect it in
+# a different format. I do expect, though, that reading will expect the same
+# format that the machine spits out.
+#
+# The idea on how to make this work, is that Accelerate needs to tell this
+# script a few things:
+#   - Where to find this data
+#   - (Something else? TODO)
+#
+# This script can then read that data and use it in a representative_data
+# function (closure?)
+# The structure of the data is preferred to be as follows: (taken from the
+# GitHub issue #3)
+#
+# {
+# "representative data": [
+#   [{ "shape": <some shape descriptor>, "data": [...data...] }, ...],
+#   [{ "shape": <the same shape descriptor>, "data": [...data...] }, ...],
+#   ...
+# ]
+# }
+#
+# Except, obviously, in binary form; the outer object is nullified in this
+# case, and the shape descriptor needs work. The data can be the verbatim
+# output of Accelerate's ByteString IO.
+#
+# EDIT: New format specified in pseudo-BNF:
+# representative_data_file -> tensor_count dataset_count dataset*
+# tensor_count -> i32
+# dataset_count -> i32
+# dataset -> shape data
+# shape -> i32 i32+ (the amount of i32s is 1 + the value of the first)
+# data -> f32+ (the amount of f32s is the product of the dimensions from the shape)
+def parse_representative_data_file(file_path):
+    with open(file_path, "rb") as f:
+        # Parse the amount of input tensors (Assume int16 for now)
+        tensor_count = read_int32(f)
+
+        # Parse the amount of representative datasets (assume int32 for now)
+        dataset_count = read_int32(f)
+
+        for _ in range(dataset_count):
+            tensors = []
+            for _ in range(tensor_count):
+                shape = read_shape(f)
+                # Parse the data (TODO assuming f32 data?)
+                data = read_data(f, shape)
+                tensors.push(data)
+
+            #end
+            yield tensors
+
+        #end
+
+    #end (I hate python's indentation rules...)
+
+
+def read_int32(f):
+    b = bytearray(4)
+    f.readinto(b)
+    return struct.unpack("l", b)[0]
+
+
+# Reads a 32-bit integer which describes the amount of dimensions the data has,
+# followed by that amount of 32-bit integers
+def read_shape(f):
+    dims = read_int32(f)
+    b = bytearray(dims * 4)
+    f.readinto(b)
+    return struct.unpack("l" * dims, b)
+
+
+# Reads f32 data, the amount of which is the product of all dimensions in the shape
+def read_data(f, shape):
+    # Apparently functional style is not "pythonic" so here we go, have a foldl
+    # (*) 1:
+    res = 1
+    for x in shape:
+        res *= x
+
+    #end
+
+    data = bytearray(res * 4)
+    f.readinto(data)
+    return struct.unpack("f" * res, data)
+
+
 # Parses command-line arguments
 # Options are:
-#   --graph_def_file=" pb_file
-#   --output_file=" tflite_file
-#   --input_arrays="  comma-separated list of names of  input arrays
-#   --output_arrays=" comma-separated list of names of output arrays
+#   --graph_def_file= pb_file
+#   --output_file= tflite_file
+#   --input_arrays=  comma-separated list of names of  input arrays
+#   --output_arrays= comma-separated list of names of output arrays
+#   --data_path= representative_data_file (see parse_representative_data_file)
 # TODO: the following changes need to happen at some point:
 #    1. sanitize the data in in_arrs and out_arrs before setting their values.
 #    2. Accept a cli-arg that describes what representative data there is, how
@@ -30,6 +122,7 @@ def parse_args(args):
     outfile = None
     in_arrs = None
     out_arrs = None
+    data_path = None
 
     for arg in args:
         if arg.startswith('--graph_def_file='):
@@ -44,8 +137,13 @@ def parse_args(args):
         elif arg.startswith('--output_arrays='):
             out_arrs = parse_array_arg(arg[16:])
             pass
+        elif arg.startswith('--data_path='):
+            data_path = arg[12:]
+            pass
+        #end
+    #end
 
-    return (graph_def, outfile, in_arrs, out_arrs)
+    return (graph_def, outfile, in_arrs, out_arrs, data_path)
 
 
 def parse_array_arg(arg):
@@ -53,7 +151,7 @@ def parse_array_arg(arg):
 
 
 def main():
-    in_file, out_file, inputs, outputs = parse_args(sys.argv)
+    in_file, out_file, inputs, outputs, data_path = parse_args(sys.argv)
 
     rng = np.random.default_rng()
 
@@ -65,7 +163,12 @@ def main():
       )
 
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: representative_data_gen(rng))
+    if data_path != None:
+        # I don't know how to break this line... Python why
+        converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: parse_representative_data_file(data_path))
+    else:
+        converter.representative_dataset = tf.lite.RepresentativeDataset(lambda: representative_data_gen(rng))
+    #end
 
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
     converter.target_spec.supported_types = [tf.int8]
@@ -73,6 +176,7 @@ def main():
     tflite_model = converter.convert()
     with tf.io.gfile.GFile(out_file, 'wb') as f:
       f.write(tflite_model)
+
 
 if __name__ == "__main__":
     main()

--- a/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
+++ b/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
@@ -115,6 +115,8 @@ tflite_model graph = do
                 , "--output_file=" ++ tf_file
                 , "--input_arrays=" ++ T.unpack (T.intercalate "," inputs)
                 , "--output_arrays=" ++ T.unpack (T.intercalate "," outputs)
+                  -- TODO: Make this file be a variable of some sorts
+                , "--data_path=" ++ "repr_data.bin"
                 ]
 
   -- Invoke 'tflite_convert' to convert the protobuf file to the tflite representation

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,10 +9,14 @@ resolver: lts-18.8
 packages:
 - accelerate-tensorflow
 - accelerate-tensorflow-lite
+- testapp
 
 extra-deps:
 - github: tmcdonell/accelerate
   commit: 78f512fe30bf1a366cb6b6b7fa70727adebf8c5f
+
+- accelerate-io-1.3.0.0
+- accelerate-io-bytestring-0.1.0.0
 
 # Stack can't handle extra-deps from github that include submodules
 - extra-deps/tensorflow-haskell/tensorflow


### PR DESCRIPTION
This merge fixes #3. Additionally, it fixes an issue with running on the TPU, where no data was copied to or from the TPU buffers. Now, the data is passed to and from the TPU; however, the results make no sense. At the moment, I think this is due to the representative data not having enough samples for the quantization to be done correctly.

I have partially investigated the issue already, and I can confirm that the arrays are correctly being passed to the TPU, and that the data I passed to the converter script was being read correctly. However, the answer the TPU gives is blatantly wrong at the moment. I'll open a new issue for this. 