### PR TITLE
Fix tensor shapes

### DIFF
--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow.hs
@@ -68,11 +68,11 @@ run | FetchableDict <- fetchableDict @arrs
 -- | Prepare an embedded array program for execution on the default
 -- TensorFlow backend
 --
-runN :: forall f. Afunction f => f -> [[Int]] -> AfunctionR f
-runN acc shapes =
+runN :: forall f. Afunction f => f -> [[Int]] -> [[Int]] -> AfunctionR f
+runN acc ishapes oshapes =
   let
       !afun  = convertAfun acc
-      !model = buildAfun shapes afun
+      !model = buildAfun ishapes oshapes afun
 
       eval :: AfunctionRepr g (AfunctionR g) (ArraysFunctionR g)
            -> OpenTfun aenv (ArraysFunctionR g)

--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow.hs
@@ -68,11 +68,11 @@ run | FetchableDict <- fetchableDict @arrs
 -- | Prepare an embedded array program for execution on the default
 -- TensorFlow backend
 --
-runN :: forall f. Afunction f => f -> AfunctionR f
-runN acc =
+runN :: forall f. Afunction f => f -> [[Int]] -> AfunctionR f
+runN acc shapes =
   let
       !afun  = convertAfun acc
-      !model = buildAfun afun
+      !model = buildAfun shapes afun
 
       eval :: AfunctionRepr g (AfunctionR g) (ArraysFunctionR g)
            -> OpenTfun aenv (ArraysFunctionR g)

--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen.hs
@@ -118,7 +118,9 @@ buildOpenAfun aenv (Alam lhs f) = do
 
                 placeholder :: TF.TensorType t => State Int (TF.Tensor TF.Build t)
                 placeholder = state $ \j ->
-                  (TF.placeholder' (TF.opName .~ TF.explicitName (T.pack (printf "input%d_adata%d" i j))), j+1)
+                  let opName = TF.opName .~ TF.explicitName (T.pack (printf "input%d_adata%d" i j))
+                      setShape = TF.opAttr "shape" .~ TF.Shape [5] -- TODO: Find correct shape
+                  in  (TF.placeholder' (setShape . opName), j+1)
         in
         (env `Apush` Tensor arrR sh' adata', i+1)
 

--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen.hs
@@ -23,6 +23,8 @@ module Data.Array.Accelerate.TensorFlow.CodeGen (
 
 ) where
 
+import Prelude as P
+
 import Data.Array.Accelerate.TensorFlow.CodeGen.AST
 import Data.Array.Accelerate.TensorFlow.CodeGen.Base
 import Data.Array.Accelerate.TensorFlow.CodeGen.Environment
@@ -63,11 +65,11 @@ import qualified Data.Text                                          as T
 buildAcc :: Acc a -> Tensors a
 buildAcc acc = buildOpenAcc Aempty acc
 
-buildAfun :: [[Int]] -> Afun f -> Tfun f
-buildAfun shapes f = evalState (buildOpenAfun shapes Aempty f) 0
+buildAfun :: [[Int]] -> [[Int]] -> Afun f -> Tfun f
+buildAfun ishapes oshapes f = evalState (buildOpenAfun ishapes oshapes Aempty f) 0
 
-buildOpenAfun :: [[Int]] -> Aval aenv -> OpenAfun aenv f -> State Int (OpenTfun aenv f)
-buildOpenAfun (sh:shs) aenv (Alam lhs f) = do
+buildOpenAfun :: [[Int]] -> [[Int]] -> Aval aenv -> OpenAfun aenv f -> State Int (OpenTfun aenv f)
+buildOpenAfun (ish:ishs) oshs aenv (Alam lhs f) = do
   let
       go :: ALeftHandSide t aenv aenv' -> Aval aenv -> State Int (Aval aenv')
       go LeftHandSideWildcard{}                      env = return env
@@ -119,18 +121,19 @@ buildOpenAfun (sh:shs) aenv (Alam lhs f) = do
                 placeholder :: TF.TensorType t => State Int (TF.Tensor TF.Build t)
                 placeholder = state $ \j ->
                   let opName = TF.opName .~ TF.explicitName (T.pack (printf "input%d_adata%d" i j))
-                      setShape = TF.opAttr "shape" .~ TF.Shape (fromIntegral <$> sh) -- TODO: Find correct shape from program
+                      -- shape' = toTfShape _shR sh'
+                      setShape = TF.opAttr "shape" .~ TF.Shape (fromIntegral <$> ish) -- TODO: Find correct shape
                   in  (TF.placeholder' (setShape . opName), j+1)
         in
         (env `Apush` Tensor arrR sh' adata', i+1)
 
   --
   aenv' <- go lhs aenv
-  f'    <- buildOpenAfun shs aenv' f
+  f'    <- buildOpenAfun ishs oshs aenv' f
   return $ Tlam lhs f'
 --
-buildOpenAfun [] aenv (Alam _ _) = error "Not enough shapes for arguments"
-buildOpenAfun shapes aenv (Abody f) =
+buildOpenAfun [] _ aenv (Alam _ _) = error "Not enough shapes for arguments"
+buildOpenAfun inshapes outshapes aenv (Abody f) =
   let
       go :: ArraysR t -> Tensors t -> State Int (Tensors t)
       go TupRunit              ()                                     = return ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,6 @@ resolver: lts-18.8
 packages:
 - accelerate-tensorflow
 - accelerate-tensorflow-lite
-- testapp
 
 extra-deps:
 - github: tmcdonell/accelerate


### PR DESCRIPTION
This fixes #6. The problem has been temporarily resolved by adding shape parameters to `accelerate-tensorflow-lite`s `runN` function. The shapes are currently of type `[Int]`, which makes these parameters `[[Int]]`; the order for the inputs should be the same as the order of the array parameters:
```haskell
runN someProgram [shX, shY] [shOut] xs ys
  where
    xs = fromList shX [0..]
    ys = fromList shY [0..]
    shX = Z :. 10
    shY = Z :. 5
```
This should run without issues (provided that the program is correct with these shapes).

The reason the shape parameters are before the actual parameters, is because we need those during Accelerate compile time, but we only get the actual parameters (`xs`, `ys`) during Accelerate run time. This approach can probably be improved a lot using shape inference, but I don't know how that works. At least by doing this, there is something that works, and it is (hopefully) clear which information is necessary in which places.

I also see that the auto-merge is failing and so that I probably can merge/rebase some new changes into this branch; let me know if this is something you prefer before merging, and I'll fix that.